### PR TITLE
feat: add RSS/Atom feed parsing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ Intelligently extract specific information from a webpage using the configured L
 
 *   (str): The extracted information (often formatted as JSON or structured text based on the instruction) or a message indicating no relevant information was found, or an error message (including if the required API key is missing).
 
+### `parse_rss_feed`
+
+Parse an RSS or Atom feed and return recent entries with title, link, published date, and summary.
+
+**Arguments:**
+
+*   `feed_url` (str, **required**): The URL of the RSS/Atom feed to parse (e.g., "https://news.ycombinator.com/rss", "https://feeds.bbci.co.uk/news/rss.xml").
+*   `max_items` (int, *optional*): Maximum number of recent items to return. Defaults to `10`, maximum is `50`.
+
+**Returns:**
+
+*   (str): A formatted list of feed entries including title, link, published date, and summary, or an error message.
+
 ## Setup and Running
 
 You can run this server either locally or using the provided Docker configuration.
@@ -170,6 +183,24 @@ Agent: Successfully extracted information based on your instruction:
     "Being integrated into Google products like Bard and Pixel."
   ]
 }
+------------------------------
+You: parse_rss_feed https://news.ycombinator.com/rss max_items=5
+Agent: Thinking...
+[Agent calls parse_rss_feed tool]
+Agent: Feed: Hacker News
+URL: https://news.ycombinator.com
+Total Entries: 30
+Showing: 5 most recent
+
+1. Show HN: My new open source project
+   Link: https://example.com/project
+   Published: Mon, 04 Mar 2026 12:00:00 GMT
+   Summary: A new tool for developers...
+
+2. The future of AI agents
+   Link: https://blog.example.com/ai-agents
+   Published: Mon, 04 Mar 2026 10:30:00 GMT
+   Summary: Exploring the possibilities...
 
 ```
 

--- a/crawl_server.py
+++ b/crawl_server.py
@@ -6,6 +6,8 @@ from bs4 import BeautifulSoup
 import json
 import os
 from dotenv import load_dotenv
+import feedparser
+from datetime import datetime
 
 load_dotenv()
 
@@ -157,6 +159,71 @@ async def smart_extract(url: str, instruction: str) -> str:
             return "Error: Google API key not found. Please set GOOGLE_API_KEY in your environment."
     except Exception as e:
         return f"Error during intelligent extraction: {str(e)}"
+
+
+@mcp.tool()
+async def parse_rss_feed(feed_url: str, max_items: int = 10) -> str:
+    """
+    Parse an RSS or Atom feed and return recent entries.
+    
+    Args:
+        feed_url: The URL of the RSS/Atom feed to parse
+        max_items: Maximum number of recent items to return (default: 10, max: 50)
+        
+    Returns:
+        A formatted list of feed entries with title, link, published date, and summary
+    """
+    try:
+        # Validate max_items
+        max_items = min(max(1, max_items), 50)
+        
+        # Parse the feed
+        feed = feedparser.parse(feed_url)
+        
+        if not feed.entries:
+            return f"No entries found in feed: {feed_url}"
+        
+        # Get feed info
+        feed_title = feed.feed.get('title', 'Unknown Feed')
+        feed_link = feed.feed.get('link', 'No link available')
+        
+        # Format entries
+        entries = []
+        for i, entry in enumerate(feed.entries[:max_items], 1):
+            title = entry.get('title', 'No title')
+            link = entry.get('link', 'No link')
+            
+            # Get published date
+            published = entry.get('published', entry.get('updated', 'No date'))
+            
+            # Get summary/description
+            summary = entry.get('summary', entry.get('description', 'No summary'))
+            # Clean up HTML if present
+            if summary and '<' in summary:
+                soup = BeautifulSoup(summary, 'html.parser')
+                summary = soup.get_text(separator=' ', strip=True)
+            # Truncate long summaries
+            if len(summary) > 500:
+                summary = summary[:500] + "..."
+            
+            entries.append(f"""
+{i}. {title}
+   Link: {link}
+   Published: {published}
+   Summary: {summary}
+""")
+        
+        result = f"""Feed: {feed_title}
+URL: {feed_link}
+Total Entries: {len(feed.entries)}
+Showing: {min(max_items, len(feed.entries))} most recent
+
+{''.join(entries)}
+"""
+        return result.strip()
+        
+    except Exception as e:
+        return f"Error parsing RSS feed: {str(e)}"
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,7 @@ python-dotenv
 # Potentially needed by crawl4ai or underlying libraries, good to include
 # httpx >= 0.27.0 # Usually installed by crawl4ai/mcp
 # beautifulsoup4 >= 4.12.2 # Usually installed by crawl4ai
+
+# RSS Feed parsing
+feedparser>=6.0.0
+beautifulsoup4>=4.12.0


### PR DESCRIPTION
## Summary

Added a new MCP tool  for fetching and parsing RSS/Atom feeds, enabling AI agents to monitor news, blogs, and other syndicated content.

## Changes

### New Tool: 

**Purpose:** Parse RSS/Atom feeds and return recent entries

**Parameters:**
-  (required): URL of the RSS/Atom feed
-  (optional): Maximum entries to return (default: 10, max: 50)

**Returns:**
- Feed title and URL
- Total number of entries
- List of recent items with:
  - Title
  - Link
  - Published date
  - Summary (HTML stripped, truncated to 500 chars)

**Example Usage:**


### Dependencies Added
-  - RSS/Atom feed parsing
-  - HTML cleaning for summaries

### Documentation
- Added tool documentation to README
- Added usage example to Example Agent Interaction section

## Use Cases

This tool enables agents to:
- Monitor news sources (BBC, Reuters, etc.)
- Track blog updates
- Follow Hacker News, Reddit RSS feeds
- Build news aggregation workflows
- Monitor competitor blogs
- Track industry trends

## Testing

Tested with feeds:
- ✅ https://news.ycombinator.com/rss
- ✅ https://feeds.bbci.co.uk/news/rss.xml
- ✅ https://www.reddit.com/r/technology/.rss

## Backwards Compatibility

No breaking changes. New tool is additive only.

---

This addition makes the MCP server more versatile for content monitoring and aggregation tasks.